### PR TITLE
custom command-line option passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Creates new `Daemon` instance. Supported `options`:
 * `silent` - disable printing info to console (default: `false`)
 * `stopTimeout` - interval of daemon killing retry (default: `2s`)
 * `args` - additional node runtime arguments, ie `--debug`
+* `argv` - additional module arguments
 
 All paths are resolved relative to file that uses "daemonize".
 
-All commandline arguments will be passed to the child process.
+All commandline arguments will be passed to the child process unless `argv` option is provided.
 
 ## Daemon
 Daemon control class. It references controlled daemon.

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -63,6 +63,8 @@ var Daemon = function(options) {
     this._options.user = options.user || "";
     this._options.group = options.group || "";
 
+    this._options.argv = Array.isArray(options.argv) ? options.argv : [];
+
     this._stopTimeout = options.stopTimeout || 2000;
 
     this._childExitHandler = null;
@@ -112,10 +114,18 @@ Daemon.prototype.start = function(listener) {
         return this;
     }
 
+    // choose between arguments in options and arguments on commandline
+    var argv;
+    if(this._options.argv.length) {
+      argv = this._options.argv;
+    } else {
+      argv = process.argv.slice(2);
+    }
+
     // spawn child process
     var child = spawn(process.execPath, (this._options.args || []).concat([
             __dirname + "/wrapper.js"
-        ]).concat(process.argv.slice(2)), {
+        ]).concat(argv), {
             env: process.env,
             stdio: ["ignore", "ignore", "ignore", "ipc"],
             detached: true


### PR DESCRIPTION
I've implemented a patch for passing not only process.argv.slice(2), but any custom arguments, provided by option argv. Could you review change and maybe integrate it, if it fits? If specified, no arguments from command line is accounted for.
