### PR TITLE
Add cwd option to daemon setup

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -63,7 +63,7 @@ var init = function(options) {
 
     // change working directory
     try {
-        process.chdir("/");
+        process.chdir(options.cwd || "/");
     }
     catch (ex) {
         process.exit(constants.exitCodes.chdirFailed[0]);


### PR DESCRIPTION
Pass in the cwd option to the setup of the daemon.

cwd defaults to the root of the system ( / ).
