### PR TITLE
Do not send the first argument to child process

### DIFF
--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -115,7 +115,7 @@ Daemon.prototype.start = function(listener) {
     // spawn child process
     var child = spawn(process.execPath, (this._options.args || []).concat([
             __dirname + "/wrapper.js"
-        ]).concat(process.argv.slice(2)), {
+        ]).concat(process.argv.slice(3)), {
             env: process.env,
             stdio: ["ignore", "ignore", "ignore", "ipc"],
             detached: true


### PR DESCRIPTION
Should be removing the first argument (e.g. 'start') and only send
following arguments to the child process.

For example:

```
node somedaemon start --arguments --here
```

Should only send `--arguments --here` to the child process. That seems to be expected behavior. Sending `start` seems a little odd.
