### PR TITLE
Do not set umask to zero by default

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -59,7 +59,8 @@ var init = function(options) {
         process.title = options.name;
 
     // change the file mode mask
-    process.umask(0);
+    if (options.umask !== undefined)
+        process.umask(options.umask);
 
     // change working directory
     try {


### PR DESCRIPTION
This is potentially dangerous. The user should be responsible for specifying a umask of 0 (or any other value) when running the daemon.

Check out this answer on StackOverflow: http://stackoverflow.com/a/7142522/315562 .
