### PR TITLE
I've added a few options to Daemon

### DIFF
--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -74,11 +74,13 @@ var Daemon = function(options) {
 
     if (!options.silent)
         this._bindConsole();
-    
-	if ( options.outStream )
-		this._options.outStream = options.outStream ;
-	if ( options.errStream )
-		this._options.errStream = options.errStream ;
+
+	if ( options.stdin )
+		this._options.stdin = options.stdin ;    
+	if ( options.stdout )
+		this._options.stdout = options.stdout ;
+	if ( options.stderr )
+		this._options.stderr = options.stderr ;
 	
 	if ( options.leaveRef ) 
 		this._options.leaveRef = true ;
@@ -126,9 +128,9 @@ Daemon.prototype.start = function(listener) {
         ]).concat(this._options.argv), {
             env: process.env,
             stdio: [
-				"ignore" ,
-				this._options.outStream || "ignore" , 
-				this._options.errStream || "ignore" , 
+				this._options.stdin || "ignore" , 
+				this._options.stdout || "ignore" , 
+				this._options.stderr || "ignore" , 
 				"ipc"
 			],
             detached: true

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -74,6 +74,12 @@ var Daemon = function(options) {
 
     if (!options.silent)
         this._bindConsole();
+    
+	if ( options.outFile ) {
+		
+		this._options.outFile = fs.openSync( options.outFile , 'a') ;
+		
+	}
 };
 util.inherits(Daemon, EventEmitter);
 
@@ -117,7 +123,12 @@ Daemon.prototype.start = function(listener) {
             __dirname + "/wrapper.js"
         ]).concat(this._options.argv), {
             env: process.env,
-            stdio: ["ignore", "ignore", "ignore", "ipc"],
+            stdio: [
+				"ignore" ,
+				this._options.outFile || "ignore" , 
+				this._options.outFile || "ignore" , 
+				"ipc"
+			],
             detached: true
         }
     );

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -75,10 +75,10 @@ var Daemon = function(options) {
     if (!options.silent)
         this._bindConsole();
     
-	if ( options.outFile )
-		this._options.outFileDescriptor = fs.openSync( options.outFile , 'w') ;
-	if ( options.errFile )
-		this._options.errFileDescriptor = fs.openSync( options.errFile , 'w') ;
+	if ( options.outStream )
+		this._options.outStream = options.outStream ;
+	if ( options.errStream )
+		this._options.errStream = options.errStream ;
 
 };
 util.inherits(Daemon, EventEmitter);
@@ -125,8 +125,8 @@ Daemon.prototype.start = function(listener) {
             env: process.env,
             stdio: [
 				"ignore" ,
-				this._options.outFileDescriptor || "ignore" , 
-				this._options.errFileDescriptor || "ignore" , 
+				this._options.outStream || "ignore" , 
+				this._options.errStream || "ignore" , 
 				"ipc"
 			],
             detached: true

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -79,7 +79,9 @@ var Daemon = function(options) {
 		this._options.outStream = options.outStream ;
 	if ( options.errStream )
 		this._options.errStream = options.errStream ;
-
+	
+	if ( options.leaveRef ) 
+		this._options.leaveRef = true ;
 };
 util.inherits(Daemon, EventEmitter);
 
@@ -170,7 +172,7 @@ Daemon.prototype.start = function(listener) {
             child.removeListener("exit", this._childExitHandler);
 
             if (this._sendSignal(pid)) {
-                this.emit("started", pid);
+                this.emit("started", pid , child );
 
             } else {
                 this.emit("error", new Error("Daemon failed to start"));
@@ -183,8 +185,10 @@ Daemon.prototype.start = function(listener) {
     child.send({type: "init", options: this._options});
 
     // remove child from reference count to make parent process exit
-    child.unref();
-
+    if ( ! this.options.leaveRef )
+		child.unref();
+	
+	
     return this;
 };
 

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -74,9 +74,13 @@ var Daemon = function(options) {
 
     if (!options.silent)
         this._bindConsole();
-
+	
+	// used for child initialization
+	
+	this._options.data = options.data ;
+	
 	if ( options.stdin )
-		this._options.stdin = options.stdin ;    
+		this._options.stdin = options.stdout ;    
 	if ( options.stdout )
 		this._options.stdout = options.stdout ;
 	if ( options.stderr )
@@ -91,7 +95,7 @@ Daemon.prototype.start = function(listener) {
 
     // make sure daemon is not running
     var pid = this._sendSignal(this._getpid());
-	var child ;
+
     if (pid) {
         this.emit("running", pid);
         if (listener) listener(null, pid);
@@ -109,7 +113,7 @@ Daemon.prototype.start = function(listener) {
 
         this.once("started", startedFunc = function(pid) {
             this.removeListener("error", errorFunc);
-            listener(null, pid , child);
+            listener(null, pid);
         }.bind(this));
     }
 
@@ -123,7 +127,7 @@ Daemon.prototype.start = function(listener) {
     }
 
     // spawn child process
-    child = spawn(process.execPath, (this._options.args || []).concat([
+    var child = spawn(process.execPath, (this._options.args || []).concat([
             __dirname + "/wrapper.js"
         ]).concat(this._options.argv), {
             env: process.env,
@@ -174,7 +178,7 @@ Daemon.prototype.start = function(listener) {
             child.removeListener("exit", this._childExitHandler);
 
             if (this._sendSignal(pid)) {
-                this.emit("started", pid );
+                this.emit("started", pid , child );
 
             } else {
                 this.emit("error", new Error("Daemon failed to start"));

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -91,7 +91,7 @@ Daemon.prototype.start = function(listener) {
 
     // make sure daemon is not running
     var pid = this._sendSignal(this._getpid());
-
+	var child ;
     if (pid) {
         this.emit("running", pid);
         if (listener) listener(null, pid);
@@ -109,7 +109,7 @@ Daemon.prototype.start = function(listener) {
 
         this.once("started", startedFunc = function(pid) {
             this.removeListener("error", errorFunc);
-            listener(null, pid);
+            listener(null, pid , child);
         }.bind(this));
     }
 
@@ -123,7 +123,7 @@ Daemon.prototype.start = function(listener) {
     }
 
     // spawn child process
-    var child = spawn(process.execPath, (this._options.args || []).concat([
+    child = spawn(process.execPath, (this._options.args || []).concat([
             __dirname + "/wrapper.js"
         ]).concat(this._options.argv), {
             env: process.env,
@@ -174,7 +174,7 @@ Daemon.prototype.start = function(listener) {
             child.removeListener("exit", this._childExitHandler);
 
             if (this._sendSignal(pid)) {
-                this.emit("started", pid , child );
+                this.emit("started", pid );
 
             } else {
                 this.emit("error", new Error("Daemon failed to start"));

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -76,9 +76,9 @@ var Daemon = function(options) {
         this._bindConsole();
     
 	if ( options.outFile )
-		this._options.outFile = options.outFile ;
+		this._options.outFile = fs.openSync( options.outFile , 'a') ;
 	if ( options.errFile )
-		this._options.errFile = options.erFile ;
+		this._options.errFile = fs.openSync( options.errFile , 'a') ;
 
 };
 util.inherits(Daemon, EventEmitter);
@@ -125,8 +125,8 @@ Daemon.prototype.start = function(listener) {
             env: process.env,
             stdio: [
 				"ignore" ,
-				this._options.outFile ?  fs.openSync( this._options.outFile , 'a') : "ignore" , 
-				this._options.errFile ? fs.openSync( this._options.errFile , 'a')  : "ignore" , 
+				this._options.outFile || "ignore" , 
+				this._options.errFile || "ignore" , 
 				"ipc"
 			],
             detached: true

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -185,7 +185,7 @@ Daemon.prototype.start = function(listener) {
     child.send({type: "init", options: this._options});
 
     // remove child from reference count to make parent process exit
-    if ( ! this.options.leaveRef )
+    if ( ! this._options.leaveRef )
 		child.unref();
 	
 	

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -76,9 +76,9 @@ var Daemon = function(options) {
         this._bindConsole();
     
 	if ( options.outFile )
-		this._options.outFile = fs.openSync( options.outFile , 'a') ;
+		this._options.outFileDescriptor = fs.openSync( options.outFile , 'w') ;
 	if ( options.errFile )
-		this._options.errFile = fs.openSync( options.errFile , 'a') ;
+		this._options.errFileDescriptor = fs.openSync( options.errFile , 'w') ;
 
 };
 util.inherits(Daemon, EventEmitter);
@@ -125,8 +125,8 @@ Daemon.prototype.start = function(listener) {
             env: process.env,
             stdio: [
 				"ignore" ,
-				this._options.outFile || "ignore" , 
-				this._options.errFile || "ignore" , 
+				this._options.outFileDescriptor || "ignore" , 
+				this._options.errFileDescriptor || "ignore" , 
 				"ipc"
 			],
             detached: true

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -75,11 +75,11 @@ var Daemon = function(options) {
     if (!options.silent)
         this._bindConsole();
     
-	if ( options.outFile ) {
-		
-		this._options.outFile = fs.openSync( options.outFile , 'a') ;
-		
-	}
+	if ( options.outFile )
+		this._options.outFile = options.outFile ;
+	if ( options.errFile )
+		this._options.errFile = options.erFile ;
+
 };
 util.inherits(Daemon, EventEmitter);
 
@@ -125,8 +125,8 @@ Daemon.prototype.start = function(listener) {
             env: process.env,
             stdio: [
 				"ignore" ,
-				this._options.outFile || "ignore" , 
-				this._options.outFile || "ignore" , 
+				this._options.outFile ?  fs.openSync( options.outFile , 'a') : "ignore" , 
+				this._options.errFile ? fs.openSync( options.errFile , 'a')  : "ignore" , 
 				"ipc"
 			],
             detached: true

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -125,8 +125,8 @@ Daemon.prototype.start = function(listener) {
             env: process.env,
             stdio: [
 				"ignore" ,
-				this._options.outFile ?  fs.openSync( options.outFile , 'a') : "ignore" , 
-				this._options.errFile ? fs.openSync( options.errFile , 'a')  : "ignore" , 
+				this._options.outFile ?  fs.openSync( this._options.outFile , 'a') : "ignore" , 
+				this._options.errFile ? fs.openSync( this._options.errFile , 'a')  : "ignore" , 
 				"ipc"
 			],
             detached: true

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-    "name": "daemonize2",
-    "version": "0.4.0-rc.7",
-    "description": "Module for easy creation of daemons for Node 0.8.x",
+    "name": "daemonize.redux",
+    "version": "0.0.1",
+    "description": "Slight revision on top of Kuba Niegowski's Daemonize 2, tested to be compatible with Node 0.10",
     "author": "Kuba Niegowski",
-    "contributors": [],
-    "homepage": "https://github.com/niegowski/node-daemonize2/",
+    "contributors": ["Gabriel Lipson","Kuba Niegowski"],
+    "homepage": "https://github.com/objectundefined/node-daemonize2",
     "keywords" : [
         "daemon"
     ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "daemon"
     ],
     "engines": {
-        "node": "0.8.x"
+        "node": "0.8.x",
+        "node": "0.10.x"
     },
     "main": "./lib/daemonize.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "daemonize2",
-    "version": "0.4.0-rc.6",
+    "version": "0.4.0-rc.7",
     "description": "Module for easy creation of daemons for Node 0.8.x",
     "author": "Kuba Niegowski",
     "contributors": [],


### PR DESCRIPTION
These were initially options I needed to move forward, but I think they are useful in general.

First, the ability to send file handles to stdout and stderr so that you can write or append output to a file.

Second, i've added a "data" property that, if set, gets curried to the child process on the init event (child.send({type:init,options....). This is often more favorable than argv.

Third, i've added a "leaveRef" property that allows one to decide weather or not a daemon should be "unref'd".

I have a process that instantiates a number of daemons and this facilitates communication between then.

Thank you,

Gabriel
