### PR TITLE
fix package.json to include repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "engines": {
         "node": ">0.8.x"
     },
-    "main": "./lib/daemonize.js"
+    "main": "./lib/daemonize.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/niegowski/node-daemonize2.git"
+    }
 }


### PR DESCRIPTION
Quick addition so that npm wouldn't warn that there isn't a repository field.
![screen shot 2014-01-20 at 8 54 37 pm](https://f.cloud.github.com/assets/132584/1960712/2d2a57be-8258-11e3-9ab0-bc5541dc0263.png)
