### PR TITLE
Added coffee-script registration support

### DIFF
--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -33,14 +33,47 @@ exports.setup = function(options) {
 };
 
 var Daemon = function(options) {
+
+    function find_coffee() {
+        var file_names = {};
+
+        function recursive_search(obj) {
+            var child, children, found, i, len, pos,
+                pattern = 'coffee-script/register.js';
+
+            if (!file_names[obj.filename]) {
+                pos = obj.filename.lastIndexOf(pattern);
+                if (pos === obj.filename.length - pattern.length) {
+                    return obj.filename;
+                }
+
+                file_names[obj.filename] = true;
+                children = obj.children;
+                for (i = 0, len = children.length; i < len; i += 1) {
+                    child = children[i];
+                    if (found = recursive_search(child)) {
+                        return found;
+                    }
+                }
+            }
+        }
+
+        return recursive_search(process.mainModule);
+    }
+
     EventEmitter.call(this);
 
     if (!options.main)
         throw new Error("Expected 'main' option for daemonize");
 
-    var dir = path.dirname(module.parent.filename),
+    var coffeePath,
+        dir = path.dirname(module.parent.filename),
         main = path.resolve(dir, options.main),
         name = options.name || path.basename(main, ".js");
+
+    if (coffeePath = find_coffee()) {
+        options.coffeePath = coffeePath;
+    }
 
     if (!this._isFile(main))
         throw new Error("Can't find daemon main module: '" + main + "'");

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -101,6 +101,11 @@ var init = function(options) {
         options.main
     ].concat(process.argv.slice(2));
 
+    // coffee-script registration
+    if (options.coffeePath) {
+        require(options.coffeePath);
+    }
+
     // run main module
     var setup = require(options.main);
 


### PR DESCRIPTION
in lib/daemonize.js:
find if coffee-script parser was registered, and if so, pass the parser to the wrapper.

in lib/wrapper.js: 
if coffee parser is passed, require it, thus allowing direct coffee script daemonizing.
