### PR TITLE
Add property to pass additional file descriptors to daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Creates new `Daemon` instance. Supported `options`:
 * `args` - additional node runtime arguments, ie `--debug`; `array` or `string`
 * `argv` - argv for daemon (default: `process.argv.slice(2)`); `array` or `string`
 * `cwd` - current working directory for spawned daemon (default: `/`); `string`
+* `fds` - array of additional file descriptors to pass to the daemon. Note that the actual descriptors passed to the daemon are `[ 'ignore', 'ignore', 'ignore', 'ipc' ].concat(fds)`, so the supplied descriptors will be available in the daemon as starting from fd 4. For more information look at [Node docs](https://nodejs.org/api/child_process.html#child_process_options_stdio).
 
 All paths are resolved relative to file that uses "daemonize".
 

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -62,6 +62,10 @@ var Daemon = function(options) {
     this._options.user = options.user || "";
     this._options.group = options.group || "";
 
+    this._options.fds = options.fds || [];
+    if (!Array.isArray(this._options.fds))
+        this._options.fds = [ this._options.fds ];
+
     if (typeof options.umask == "undefined")
         this._options.umask = 0;
     else if (typeof options.umask == "string")
@@ -121,7 +125,7 @@ Daemon.prototype.start = function(listener) {
             __dirname + "/wrapper.js"
         ]).concat(this._options.argv), {
             env: process.env,
-            stdio: ["ignore", "ignore", "ignore", "ipc"],
+            stdio: ["ignore", "ignore", "ignore", "ipc"].concat(this._options.fds),
             detached: true
         }
     );


### PR DESCRIPTION
This pull request adds a new option `fds` to allow passing a daemon additional file descriptors. It just allows to append descriptors to the `stdio` option when spawning the new process.
