### PR TITLE
Allow setting stdio and stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .project
+
+examples/*/node_modules
+examples/*/*.log

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "redirect",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+    "daemonize2": "file:../.."
+  },
+  "license": "MIT"
+}

--- a/examples/redirect/app.js
+++ b/examples/redirect/app.js
@@ -1,0 +1,16 @@
+var http = require("http");
+
+http.createServer(function(req, res) {
+    console.log("Beginning request.");
+
+    res.writeHead(200, {
+        "Content-Type": "text/plain"
+    });
+    res.end("Hello World");
+
+    console.log("Ending request.");
+}).listen(8080);
+
+setInterval(function () {
+  console.error("A theoretical error!");
+}, 1000);

--- a/examples/redirect/ctrl.js
+++ b/examples/redirect/ctrl.js
@@ -1,0 +1,35 @@
+var fs = require('fs');
+
+var daemon = require("daemonize2").setup({
+    main: "app.js",
+    name: "sampleapp",
+    pidfile: "sampleapp.pid"
+});
+
+var outFile = "sampleapp.out.log";
+var errFile = "sampleapp.err.log";
+
+switch (process.argv[2]) {
+
+    case "start":
+        var outStream = fs.createWriteStream(outFile);
+        var errStream = fs.createWriteStream(errFile);
+
+        outStream.on('open', function () {
+            errStream.on('open', function () {
+                daemon.start(undefined, {
+                    stdout: outStream,
+                    stderr: errStream
+                });
+            });
+        });
+
+        break;
+
+    case "stop":
+        daemon.stop();
+        break;
+
+    default:
+        console.log("Usage: [start|stop]");
+}

--- a/examples/redirect/package.json
+++ b/examples/redirect/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "redirect",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+    "daemonize2": "file:../.."
+  },
+  "license": "MIT"
+}

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "redirect",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+    "daemonize2": "file:../.."
+  },
+  "license": "MIT"
+}

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -81,7 +81,8 @@ var Daemon = function(options) {
 };
 util.inherits(Daemon, EventEmitter);
 
-Daemon.prototype.start = function(listener) {
+Daemon.prototype.start = function(listener, stdio) {
+    stdio = stdio || {};
 
     // make sure daemon is not running
     var pid = this._sendSignal(this._getpid());
@@ -116,12 +117,16 @@ Daemon.prototype.start = function(listener) {
         return this;
     }
 
+    // check if stdout and stderr
+    var stdout = stdio.stdout || "ignore";
+    var stderr = stdio.stderr || "ignore";
+
     // spawn child process
     var child = spawn(process.execPath, (this._options.args || []).concat([
             __dirname + "/wrapper.js"
         ]).concat(this._options.argv), {
             env: process.env,
-            stdio: ["ignore", "ignore", "ignore", "ipc"],
+            stdio: ["ignore", stdout, stderr, "ipc"],
             detached: true
         }
     );


### PR DESCRIPTION
Added a new parameter to Daemon.start for configuring stdio and stderr, this can be used as seen in the redirect example to redirect stdout and stderr to files. This is very useful for instrumenting processes whose logging cannot be easily changed.
